### PR TITLE
optimize email list id unnesting

### DIFF
--- a/.buildkite/scripts/run_models.sh
+++ b/.buildkite/scripts/run_models.sh
@@ -17,7 +17,10 @@ echo `pwd`
 cd integration_tests
 dbt deps
 dbt seed --target "$db" --full-refresh
+dbt compile --target "$db"
 dbt run --target "$db" --full-refresh
+dbt run --target "$db"
 dbt test --target "$db"
 dbt run --vars '{iterable__using_campaign_label_history: false, iterable__using_user_unsubscribed_message_type_history: false, iterable__using_campaign_suppression_list_history: false, iterable__using_user_device_history: true}' --target "$db" --full-refresh
+dbt run --vars '{iterable__using_campaign_label_history: false, iterable__using_user_unsubscribed_message_type_history: false, iterable__using_campaign_suppression_list_history: false, iterable__using_user_device_history: true}' --target "$db"
 dbt test --target "$db"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 
 ## 🚨 Breaking Changes 🚨
 - Adjusts the default materialization of `int_iterable__list_user_history` from a view to a table. This was changed to optimize the runtime of the downstream `int_iterable__list_user_unnest` model.
-- Updates `int_iterable__list_user_unnest` to be materialized as an incremental table. In order to add this logic, we also added a new `unique_key` field -- a surrogate key hashed on `email`, `list_id`, and `updated_at`.
-  - **You will need to run a full refresh first to pick up the new column**.
+- Updates `int_iterable__list_user_unnest` to be materialized as an incremental table. In order to add this logic, we also added a new `unique_key` field -- a surrogate key hashed on `email`, `list_id`, and `updated_at` -- and a `date_day` field to partition by on Bigquery + Databricks.
+  - **You will need to run a full refresh first to pick up the new columns**.
 
 ## Under the Hood
 - Adds a `coalesce` to `previous_email_ids` in the `int_iterable__list_user_history` model, in case there are no previous email ids.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Under the Hood
 - Adds a `coalesce` to `previous_email_ids` in the `int_iterable__list_user_history` model, in case there are no previous email ids.
+- Adjusts the `flatten` logic in `int_iterable__list_user_unnest` for Snowflake users.
 
 # dbt_iterable v0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# dbt_iterable v0.7.0
+PR #update adds the following changes:
+
+## 🚨 Breaking Changes 🚨
+- Adjusts the default materialization of `int_iterable__list_user_history` from a view to a table. This was changed to optimize the runtime of the downstream `int_iterable__list_user_unnest` model.
+- Updates `int_iterable__list_user_unnest` to be materialized as an incremental table. In order to add this logic, we also added a new `unique_key` field -- a surrogate key hashed on `email`, `list_id`, and `updated_at`.
+  - **You will need to run a full refresh first to pick up the new column**.
+
+## Under the Hood
+- Adds a `coalesce` to `previous_email_ids` in the `int_iterable__list_user_history` model, in case there are no previous email ids.
+
 # dbt_iterable v0.6.0
 
 ## 🚨 Breaking Changes 🚨

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # dbt_iterable v0.7.0
-PR #update adds the following changes:
+[PR #28](https://github.com/fivetran/dbt_iterable/pull/28) adds the following changes:
 
 ## 🚨 Breaking Changes 🚨
 - Adjusts the default materialization of `int_iterable__list_user_history` from a view to a table. This was changed to optimize the runtime of the downstream `int_iterable__list_user_unnest` model.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Include the following Iterable package version in your `packages.yml` file.
 ```yaml
 packages:
   - package: fivetran/iterable
-    version: [">=0.6.0", "<0.7.0"]
+    version: [">=0.7.0", "<0.8.0"]
 ```
 ## Step 3: Define database and schema variables
 By default, this package runs using your destination and the `iterable` schema of your [target database](https://docs.getdbt.com/docs/running-a-dbt-project/using-the-command-line-interface/configure-your-profile). If this is not where your Iterable data is located (for example, if your Iterable schema is named `iterable_fivetran`), add the following configuration to your root `dbt_project.yml` file:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -9,6 +9,8 @@ models:
     intermediate:
       +materialized: view
       +schema: int_iterable
+      int_iterable__list_user_history:
+        +materialized: table
 vars:
   iterable:
     campaign_history: "{{ ref('stg_iterable__campaign_history') }}"

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'iterable'
-version: '0.6.0'
+version: '0.7.0'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]
 models:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -44,3 +44,6 @@ seeds:
     user_unsubscribed_message_type_history_data:
       +column_types:
         message_type_id: "{%- if target.type == 'bigquery' -%} INT64 {%- else -%} bigint {%- endif -%}"
+    user_history_data:
+      +column_types:
+        updated_at: timestamp

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -4,7 +4,7 @@ version: '0.6.0'
 profile: 'integration_tests'
 vars:
   iterable_source:
-    iterable_schema: iterable_integration_tests
+    iterable_schema: dbt_jamie
     iterable_campaign_history_identifier: "campaign_history_data"
     iterable_campaign_label_history_identifier: "campaign_label_history_data"
     iterable_campaign_list_history_identifier: "campaign_list_history_data"

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,10 +1,10 @@
 config-version: 2
 name: 'iterable_integration_tests'
-version: '0.6.0'
+version: '0.7.0'
 profile: 'integration_tests'
 vars:
   iterable_source:
-    iterable_schema: dbt_jamie
+    iterable_schema: iterable_integration_tests
     iterable_campaign_history_identifier: "campaign_history_data"
     iterable_campaign_label_history_identifier: "campaign_label_history_data"
     iterable_campaign_list_history_identifier: "campaign_list_history_data"

--- a/integration_tests/seeds/user_history_data.csv
+++ b/integration_tests/seeds/user_history_data.csv
@@ -1,3 +1,11 @@
-email,updated_at,first_name,last_name,phone_number,user_id,signup_date,signup_source,phone_number_carrier,phone_number_country_code_iso,phone_number_line_type,phone_number_updated_at,_fivetran_synced,email_list_ids
-glennclose@hoodwinked.com,2021-06-03 08:18:30.000,,,,,2021-06-03 08:14:55.000,Import,,,,,2021-06-03 09:18:13.877,"[826724,884398]"
-innitluv@theguardian.co.uk,2021-06-03 08:32:01.000,,,,,2021-06-03 08:32:01.000,API,,,,,2021-06-03 09:18:13.708,"[]"
+email,updated_at,_fivetran_synced,email_list_ids,first_name,last_name,phone_number,phone_number_carrier,phone_number_country_code_iso,phone_number_details,phone_number_line_type,phone_number_updated_at,signup_date,signup_source,user_id
+person1@email.com,2018-09-14 08:29:13,2021-03-29 17:14:01,[162418],,,,,,,,,2018-09-14 08:29:13,Import,
+person2@email.com,2018-09-18 17:24:11,2021-03-29 17:14:01,[163833],,,,,,,,,2018-09-18 17:22:15,API,
+person3@email.com,2018-09-19 10:06:24,2021-03-29 17:14:01,[164228],,,,,,,,,2018-09-19 10:06:24,Import,22222
+person4@email.com,2018-10-05 05:37:24,2021-03-29 17:14:01,"[159258,159261,162418]",person4,,,,,,,,2018-09-06 10:18:17,Import,string
+person5@email.com,2018-10-05 05:46:47,2021-03-29 17:14:01,"[159246,159258,159261,162418,163833,173413]",person5,five,,ZZZ,0,,Phone,,2018-09-06 9:11:43,Import,1111
+person6@email.com,2018-10-06 11:36:18,2021-03-29 17:14:01,[173950],,,,,,,,,2018-10-06 11:36:18,Import,
+person7@email.com,2021-04-20 20:31:29,2021-04-20 20:56:40,[953900],,,,,,,,,2021-04-20 20:31:30,Import,
+person8@email.com,2021-04-20 20:43:37,2021-04-20 20:56:40,[953900],,,,,,,,,2021-04-20 20:30:16,Import,
+person9@gmail.com,2021-04-21 20:21:29,2021-04-21 20:28:04,[],,,,,,,,,2021-04-21 20:21:29,API,person_test
+person8@email.com,2021-04-21 20:59:40,2021-04-21 21:01:52,[953900],,,,,,,,,2021-04-20 20:30:16,Import,

--- a/models/intermediate/int_iterable__list_user_history.sql
+++ b/models/intermediate/int_iterable__list_user_history.sql
@@ -26,7 +26,7 @@ with user_history as (
         updated_at
 
     from previous_email_list_ids
-    where email_list_ids != previous_ids -- list ids are always stored in their arrays in numerical order
+    where email_list_ids != coalesce(previous_ids, 'this is new') -- list ids are always stored in their arrays in numerical order
 
 ), most_recent_list_ids as (
 

--- a/models/intermediate/int_iterable__list_user_unnest.sql
+++ b/models/intermediate/int_iterable__list_user_unnest.sql
@@ -2,7 +2,8 @@
         materialized='incremental',
         unique_key='unique_key',
         incremental_strategy='insert_overwrite' if target.type in ('bigquery', 'spark', 'databricks') else 'delete+insert',
-        file_format='delta'
+        file_format='delta',
+        on_schema_change='fail'
     ) 
 }}
 

--- a/models/intermediate/int_iterable__list_user_unnest.sql
+++ b/models/intermediate/int_iterable__list_user_unnest.sql
@@ -79,7 +79,7 @@ with user_history as (
 
     {% if target.type == 'snowflake' %}
     cross join 
-        table(flatten(cast(email_list_ids as VARIANT))) as email_list_id 
+        table(flatten(input => parse_json(email_list_ids))) as email_list_id
     {% elif target.type == 'bigquery' %}
     cross join 
         unnest(JSON_EXTRACT_STRING_ARRAY(email_list_ids)) as email_list_id

--- a/models/intermediate/int_iterable__list_user_unnest.sql
+++ b/models/intermediate/int_iterable__list_user_unnest.sql
@@ -1,27 +1,59 @@
-{{ config( materialized='table') }}
+{{ config(materialized='table',
+            unique_key='unique_key',
+            incremental_strategy='insert_overwrite' if target.type in ('bigquery', 'spark', 'databricks') else 'delete+insert',
+            file_format='delta'
+        ) 
+}}
 -- materializing as a table because the computations here are fairly complex
 
 with user_history as (
 
     select * 
-    from {{ ref('int_iterable__list_user_history') }}
+    from {{ ref('int_iterable__list_user_history') }} as user_history
 
-/*
-Unfortunately, `email_list_ids` are brought in as a JSON ARRAY, which different destinations handle completely differently. 
-The below code serves to extract and pivot list IDs into individual rows. 
-Records with an empty `email_list_ids` array will just have one row. 
-We are making the assumption that a user will not have more than 1000 lists. If that's wrong please open an issue!
-https://github.com/fivetran/dbt_iterable/issues/new/choose
-*/
+    {% if is_incremental() %}
+    where user_history.updated_at >= coalesce((select max({{this}}.updated_at) from {{ this }}), '1900-01-01')
+    {% endif %}
+
 {% if target.type == 'redshift' %}
-), numbers as (
-    select 0 as generated_number
-    union 
-    select *
-    from (
-        {{ dbt_utils.generate_series(upper_bound=1000) }} )
-{% endif %}
+), redshift_parse_email_lists as (
+
+    select
+        email,
+        first_name,
+        last_name,
+        user_id,
+        signup_date,
+        signup_source,
+        phone_number,
+        updated_at,
+        is_current,
+        email_list_ids,
+        json_parse(case when email_list_ids = '[]' then '["is_null"]' else email_list_ids end) as super_email_list_ids
+        
+    from user_history
+
 ), unnest_email_array as (
+
+    select
+        email,
+        first_name,
+        last_name,
+        user_id,
+        signup_date,
+        signup_source,
+        phone_number,
+        updated_at,
+        is_current,
+        cast(email_list_ids as {{ dbt.type_string() }}) as email_list_ids,
+        cast(email_list_id as {{ dbt.type_string() }}) as email_list_id
+
+    from redshift_parse_email_lists as emails, emails.super_email_list_ids as email_list_id
+
+{% else %}
+
+), unnest_email_array as (
+
     select
         email,
         first_name,
@@ -36,8 +68,6 @@ https://github.com/fivetran/dbt_iterable/issues/new/choose
         case when email_list_ids != '[]' then
         {% if target.type == 'snowflake' %}
         email_list_id.value
-        {% elif target.type == 'redshift' %}
-        json_extract_array_element_text(email_list_ids, cast(numbers.generated_number as {{ dbt.type_int() }}), true) 
         {% else %} email_list_id
         {% endif %}
         else null end 
@@ -46,23 +76,40 @@ https://github.com/fivetran/dbt_iterable/issues/new/choose
 
     from user_history
 
-    cross join 
     {% if target.type == 'snowflake' %}
+    cross join 
         table(flatten(cast(email_list_ids as VARIANT))) as email_list_id 
     {% elif target.type == 'bigquery' %}
+    cross join 
         unnest(JSON_EXTRACT_STRING_ARRAY(email_list_ids)) as email_list_id
-    {% elif target.type == 'redshift' %}
-        numbers 
-    where numbers.generated_number < json_array_length(email_list_ids, true)
-        or (numbers.generated_number + json_array_length(email_list_ids, true) = 0)
     {% else %}
     /* postgres */
+    cross join 
         json_array_elements_text(cast((
             case when email_list_ids = '[]' then '["is_null"]'  -- to not remove empty array-rows
             else email_list_ids end) as json)) as email_list_id
     {%- endif %}
 
+{%- endif -%}
+), adjust_nulls as (
+
+    select
+        email,
+        first_name,
+        last_name,
+        user_id,
+        signup_date,
+        signup_source,
+        updated_at,
+        phone_number,
+        is_current,
+        case when email_list_ids = '["is_null"]' then '[]' else email_list_ids end as email_list_ids,
+        cast(NULLIF(email_list_id, 'is_null') as {{ dbt.type_int() }}) as list_id
+
+    from unnest_email_array
+
 ), final as (
+
     select
         email,
         first_name,
@@ -74,8 +121,10 @@ https://github.com/fivetran/dbt_iterable/issues/new/choose
         phone_number,
         is_current,
         email_list_ids,
-        cast(email_list_id as {{ dbt.type_int() }}) as list_id
-    from unnest_email_array
+        list_id,
+        {{ dbt_utils.generate_surrogate_key(["email", "list_id", "updated_at"]) }} as unique_key
+    
+    from adjust_nulls
 )
 
 select *


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
internal

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package and how to leverage this new feature. -->
- updates Redshift's method for unnesting email list ids in `int_iterable__list_user_unnest`
- adds incremental materialization to `int_iterable__list_user_unnest`
  - adds new `unique_key` field to this model to serve as the incremental key 
  - adds new `date_day` field to partition by 
- changes materialization of `int_iterable__list_user_history` from view to table so we don't need to recreate it each time 
- adds coalesce to `previous_email_ids` to the `int_iterable__list_user_history` model in case there are no previous email ids (ie the `lag` returns `null`)
- adds comments/makes comment style consistent 
- updates flatten syntax for Snowflake people

**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes (please provide breaking change details below.)
- [ ] No  (please provide an explanation as to how the change is non-breaking below.)

they need to run a full-refresh first to get thew new `unique_key` column totally populated

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes, Issue https://github.com/fivetran/dbt_iterable/issues/26
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] Buildkite). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Buildkite <!--- Buildkite testing is only applicable to Fivetran employees. --> 
- [x] Local (please provide additional testing details below)

I tested on our seed data, using the currently published version of the package and this working branch. i compared the output of `int_iterable__list_user_unnest` and confirmed that list_ids were split out identically in Redshift using the old generate_series method vs json_parse. 
<img width="1215" alt="image" src="https://user-images.githubusercontent.com/65564846/235750472-400a4b52-0cb2-451b-8fb9-a97dd22a7ab0.png">

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] BigQuery
- [x] Redshift
- [ ] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
🍹 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
